### PR TITLE
Добавить учебный курс по проекту Alterator

### DIFF
--- a/study/chapter01-overview.html
+++ b/study/chapter01-overview.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 1. Общая архитектура</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a></nav>
+  <h1>Глава 1. Общая архитектура</h1>
+  <p>Alterator — платформа для описания системных сущностей (сервисов, компонентов, диагностик) в формате Alterator Entry и управления ими через D-Bus-менеджер. Стек включает менеджер процессов, спецификацию метаданных, GUI и вспомогательные утилиты.</p>
+  <h2>Ключевые понятия</h2>
+  <ul>
+    <li><strong>Alterator Entry</strong> — файл в формате TOML, описывающий сущность (service, backend, component и др.). Спецификация представлена в <a href="../alterator-entry/doc/README.md">alterator-entry/doc/README.md</a>.</li>
+    <li><strong>Alterator Manager</strong> — системная служба, которая загружает backend-файлы, экспортирует D-Bus-дерево и делегирует вызовы в модули. Основная документация находится в <a href="../alterator-manager/docs/README-ru.md">alterator-manager/docs/README-ru.md</a>.</li>
+    <li><strong>Модули</strong> — динамические библиотеки, расширяющие менеджер (executor, remote и др.). Они размещаются в каталоге модулей и подключаются через <code>alterator_manager_modules.c</code>.</li>
+    <li><strong>Интерфейсы</strong> — DBus-интерфейсы (service1, diag1, manager и др.), описанные XML-файлами в пакетах (например, <a href="../alterator-interface-service/org.altlinux.alterator.service1.xml">org.altlinux.alterator.service1.xml</a>).</li>
+    <li><strong>Helper-скрипты</strong> — утилиты, реализующие развёртывание/настройку сервисов (см. <a href="../alterator-test-services/test-services-helper">alterator-test-services/test-services-helper</a>).</li>
+  </ul>
+  <h2>Слоистая модель</h2>
+  <ol>
+    <li><strong>Уровень описаний</strong>. Содержит наборы Entry-файлов для сервисов (<code>.service</code>), backend-интерфейсов (<code>.backend</code>), компонентов, диагностик. Форматы нормируются схемами из каталога <a href="../alterator-entry/schemas">alterator-entry/schemas</a>.</li>
+    <li><strong>Уровень менеджера</strong>. Демон <code>alterator-manager</code> читает backend-файлы, регистрирует объекты и следит за изменениями (см. функции в <a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a> и <a href="../alterator-manager/alterator_manager_backend_monitor.c">alterator_manager_backend_monitor.c</a>).</li>
+    <li><strong>Уровень модулей</strong>. Модули предоставляют vtable методов и реализацию логики (например, executor запускает команды, remote строит ssh-туннели). Менеджер загружает их динамически через код в <a href="../alterator-manager/alterator_manager_modules.c">alterator_manager_modules.c</a>.</li>
+    <li><strong>Уровень прикладных сервисов</strong>. Сервисы ALT Services описываются Entry-файлами и реализуются helper-скриптами (пример в <a href="../alterator-service-chrony/service-chrony.backend">service-chrony.backend</a> и <a href="../alterator-service-chrony/service-chrony/service-chrony">service-chrony/service-chrony</a>).</li>
+    <li><strong>Пользовательские интерфейсы</strong>. GUI (alterator-manager-services) и CLI (alteratorctl) используют D-Bus-интерфейсы и отображают информацию из менеджера (см. <a href="../alterator-manager-servises.wiki">alterator-manager-servises.wiki</a> и <a href="../alteratorctl/main.c">alteratorctl/main.c</a>).</li>
+  </ol>
+  <h2>Главные потоки данных</h2>
+  <ul>
+    <li><em>Описание → Менеджер</em>: при старте менеджер сканирует <code>/usr/share/alterator/backends</code> и <code>/etc/alterator/backends</code>, парсит TOML-описания и загружает их в память. Разбор реализован функциями <code>read_backend_file_names</code> и <code>save_methods_environment</code> в <a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a>.</li>
+    <li><em>Менеджер → Модули</em>: во время вызова метода менеджер извлекает модуль и вызывает зарегистрированную vtable. Модуль executor читает поле <code>execute</code> и запускает внешнюю программу (описано в разделе «executor» файла <a href="../alterator-manager/docs/README-ru.md">README-ru.md</a>).</li>
+    <li><em>Сервис → Пользователь</em>: helper возвращает код и stdout/строки. Эти данные передаются либо как результат вызова, либо через сигналы, имена которых перечислены в разделе «Сигналы» спецификации интерфейса service (<a href="../alterator-interface-service/doc/README.md">alterator-interface-service/doc/README.md</a>).</li>
+    <li><em>Конфигурация → Проверка</em>: Alterator Entry проверяется по JSON Schema с помощью <code>alterator-entry validate</code> (см. <a href="../alterator-entry/scripts/alterator-entry">scripts/alterator-entry</a> и функции в <a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>).</li>
+  </ul>
+  <h2>Роли компонентов</h2>
+  <dl>
+    <dt>alterator-manager</dt>
+    <dd>Запускается systemd-юнитом <a href="../alterator-manager/alterator-manager.service">alterator-manager.service</a>, регистрирует имя <code>org.altlinux.alterator</code> и предоставляет корневой интерфейс <code>org.altlinux.alterator.manager</code> (<a href="../alterator-manager/alterator_manager_default_interfaces.c">alterator_manager_default_interfaces.c</a>).</dd>
+    <dt>alterator-entry</dt>
+    <dd>Библиотека и CLI для работы с Entry-файлами: чтение полей, валидация, извлечение пакетов из изданий (<a href="../alterator-entry/scripts/editions2packages">scripts/editions2packages</a>).</dd>
+    <dt>alterator-interface-service</dt>
+    <dd>Описывает D-Bus-интерфейс сервисов и политику безопасности (<a href="../alterator-interface-service/doc/README.md">doc/README.md</a>, <a href="../alterator-interface-service/org.altlinux.alterator.service1.policy">org.altlinux.alterator.service1.policy</a>).</dd>
+    <dt>alterator-manager-services</dt>
+    <dd>Графический фронтенд, представляющий список сервисов и кнопки управления, как описано в <a href="../alterator-manager-servises.wiki">alterator-manager-servises.wiki</a>.</dd>
+    <dt>alteratorctl</dt>
+    <dd>Консольная утилита, подключающаяся к менеджеру и предоставляющая команды управления (инициализация модулей показана в <a href="../alteratorctl/main.c">alteratorctl/main.c</a>).</dd>
+  </dl>
+  <p>В следующих главах рассматриваются форматы описаний, работа менеджера, устройство модулей и подход к созданию сервисов.</p>
+</body>
+</html>

--- a/study/chapter02-entry-model.html
+++ b/study/chapter02-entry-model.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 2. Формат Alterator Entry и схемы</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter01-overview.html">Предыдущая глава</a></nav>
+  <h1>Глава 2. Формат Alterator Entry и схемы</h1>
+  <p>Alterator Entry — TOML-описание сущностей Alterator. Файлы содержат метаданные об интерфейсах, сервисах, компонентах и диагностических инструментах. Спецификация описана в <a href="../alterator-entry/doc/README.md">alterator-entry/doc/README.md</a>.</p>
+  <h2>Нотация и именование</h2>
+  <ul>
+    <li>Расширение соответствует типу: <code>.service</code>, <code>.backend</code>, <code>.object</code>, <code>.component</code> и др. (<a href="../alterator-entry/doc/README.md">Раздел «Именование файлов»</a>).</li>
+    <li>Файлы системного уровня размещаются в <code>/usr/share/alterator/&lt;директория сущности&gt;</code>, пользовательские — в <code>/etc/alterator/&lt;...&gt;</code>. Карта директорий приведена в таблице раздела «Идентификатор Alterator entry» (<a href="../alterator-entry/doc/README.md">README</a>).</li>
+    <li>Backend-файлы различают режимы <code>system</code> и <code>user</code>: пользовательские варианты складываются в подкаталог <code>backends/user/</code> (<a href="../alterator-entry/doc/README.md">README</a>).</li>
+  </ul>
+  <h2>Структура файла</h2>
+  <p>Каждый Entry-файл — набор таблиц TOML:</p>
+  <ul>
+    <li>Корневая таблица содержит ключи <code>type</code>, <code>name</code>, <code>display_name.*</code>, <code>comment.*</code> и др. Пример <code>.service</code> показан в <a href="../alterator-test-services/test_service1/test_service1.service">alterator-test-services/test_service1/test_service1.service</a>.</li>
+    <li>Комментарии начинаются с <code>#</code> и должны сохраняться при перезаписи (<a href="../alterator-entry/doc/README.md">Раздел «Комментарии»</a>).</li>
+    <li>Группы объявляются квадратными скобками (<code>[group]</code>) и описывают параметры, ресурсы, методы. Ключи чувствительны к регистру (<a href="../alterator-entry/doc/README.md">Раздел «Заголовки групп»</a>).</li>
+    <li>Типы значений ограничены: <code>string</code>, <code>localestring</code>, <code>iconstring</code>, <code>stringlist</code>, <code>command</code>, <code>boolean</code>, <code>numeric</code> (<a href="../alterator-entry/doc/README.md">Раздел «Возможные типы значений»</a>).</li>
+  </ul>
+  <h2>Специализированные секции</h2>
+  <h3>Параметры сервиса</h3>
+  <p>Параметры описываются блоками <code>[parameters.&lt;имя&gt;]</code>, где задаются тип, контекст, значения по умолчанию, ограничения. Образец с составными типами приведён в тестовом сервисе (<a href="../alterator-test-services/test_service1/test_service1.service">test_service1.service</a>).</p>
+  <p>Для сложных объектов используется <code>type = "object"</code> и вложенная секция <code>.properties</code>. Можно включить <code>exclusive = true</code> для групп взаимоисключающих параметров (<a href="../alterator-test-services/test_service1/test_service1.service">пример group_param</a>).</p>
+  <h3>Ресурсы</h3>
+  <p>Секция <code>[resources.&lt;имя&gt;]</code> описывает файлы, директории, systemd-юниты и порты. Для портов задаётся <code>inet_service.value</code> и протоколы <code>tcp</code>/<code>udp</code>; допускается привязка к параметру через <code>inet_service.parameter</code> (<a href="../alterator-test-services/test_service1/test_service1.service">пример overridable_port</a>).</p>
+  <h3>Diag tools и services</h3>
+  <p>Сервисы могут ссылаться на диагностические инструменты через секцию <code>[diag_tools]</code> с указанием шины и пути (<a href="../alterator-test-services/test_service1/test_service1.service">пример diag_tools.tool1</a>).</p>
+  <h2>JSON Schema и проверка</h2>
+  <p>Каждому типу соответствует JSON Schema: <code>service.schema.json</code>, <code>backend.schema.json</code>, <code>component.schema.json</code> и др. (<a href="../alterator-entry/schemas">alterator-entry/schemas</a>). Валидация выполняется через функцию <code>validate()</code> библиотеки <a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>, которая подбирает схему по полю <code>type</code> и вызывает <code>jsonschema.validate</code>.</p>
+  <p>CLI-утилита <code>alterator-entry</code> поддерживает команду <code>validate</code>, обрабатывающую несколько файлов (см. <a href="../alterator-entry/scripts/alterator-entry">scripts/alterator-entry</a>). Для получения значения поля используется команда <code>alterator-entry get &lt;файл&gt; &lt;путь&gt;</code>, реализованная в функции <code>get_field()</code> (<a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>).</p>
+  <h2>Извлечение пакетов из изданий</h2>
+  <p>Издания (<code>.edition</code>) описывают наборы компонентов и пакетов. Функция <code>extract_packages_from_edition()</code> читает секции, открывает файлы компонентов и собирает пакеты с учётом архитектуры, окружения и языка (<a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>). Скрипт <a href="../alterator-entry/scripts/editions2packages">editions2packages</a> предоставляет CLI-обёртку с фильтрами по секциям, десктопам, языкам.</p>
+  <h2>Практические рекомендации</h2>
+  <ul>
+    <li>Перед добавлением нового Entry-файла запустите <code>alterator-entry validate</code> для проверки схемы.</li>
+    <li>Сохраняйте комментарии и порядок ключей: менеджер не удаляет неизвестные поля, что позволяет расширять формат без потерь (<a href="../alterator-entry/doc/README.md">README</a>).</li>
+    <li>Для backend-файлов соблюдайте ограничения на имена методов и action_id: только латиница, цифры, подчёркивания/дефисы. Проверки встроены в <a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a>.</li>
+  </ul>
+  <p>Понимание структуры Entry-файлов необходимо для настройки менеджера и описания новых сервисов, что рассматривается в следующей главе.</p>
+</body>
+</html>

--- a/study/chapter03-manager-runtime.html
+++ b/study/chapter03-manager-runtime.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 3. Alterator Manager и цикл выполнения</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter02-entry-model.html">Предыдущая глава</a></nav>
+  <h1>Глава 3. Alterator Manager и цикл выполнения</h1>
+  <p>Alterator Manager — системный демон, который читает backend-описания, публикует D-Bus-интерфейсы и маршрутизирует вызовы к модулям. Основные детали реализованы в исходниках каталога <a href="../alterator-manager">alterator-manager</a> и описаны в <a href="../alterator-manager/docs/README-ru.md">docs/README-ru.md</a>.</p>
+  <h2>Запуск и инициализация</h2>
+  <p>Менеджер стартует под управлением systemd-юнита <a href="../alterator-manager/alterator-manager.service">alterator-manager.service</a>. Точка входа в <a href="../alterator-manager/main.c">main.c</a> разбирает параметры командной строки (<code>--debug</code>, <code>--user</code>), включает журналирование и выполняет последовательность инициализации:</p>
+  <ol>
+    <li><strong>alterator_manager_backends_init()</strong> — загрузка backend-файлов из системных и пользовательских каталогов.</li>
+    <li><strong>alterator_manager_polkit_init()</strong> — настройка проверки прав (пропускается в режиме <code>--user</code>).</li>
+    <li><strong>alterator_manager_sender_environment_init()</strong> — подготовка таблицы переменных окружения для клиентов D-Bus.</li>
+    <li><strong>alterator_manager_modules_init()</strong> — загрузка модулей из каталога <code>MODULES_DIR</code> через <a href="../alterator-manager/alterator_manager_modules.c">alterator_manager_modules.c</a>.</li>
+    <li><strong>alterator_manager_default_interfaces_init()</strong> — регистрация корневого интерфейса <code>org.altlinux.alterator.manager</code>.</li>
+    <li><strong>alterator_manager_backend_monitor_init()</strong> — запуск мониторинга файлов backend для перезапуска службы при изменениях.</li>
+    <li><strong>alterator_manager_dbus_init()</strong> — публикация имени <code>org.altlinux.alterator</code> на шине.</li>
+  </ol>
+  <p>Главный цикл <code>GMainLoop</code> обрабатывает события D-Bus и таймеры: очистку окружения клиентов и проверку изменения файлов (<a href="../alterator-manager/main.c">main.c</a>).</p>
+  <h2>Модель данных</h2>
+  <p>Менеджер хранит информацию о backend-файлах в многоуровневой хеш-таблице <code>backends_data</code> (<a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a>):</p>
+  <ul>
+    <li>Ключ верхнего уровня — <em>node_name</em>, соответствующий объекту D-Bus.</li>
+    <li>Значение — таблица интерфейсов, где ключом является имя интерфейса, а значением — структура <code>InterfaceObjectInfo</code> с полями <code>module_name</code>, <code>action_id</code>, <code>interface_introspection</code>, <code>methods</code>, <code>thread_limit</code> (<a href="../alterator-manager/docs/README-ru.md">Раздел «Хранение данных»</a>).</li>
+    <li>В структуре метода (<code>MethodObjectInfo</code>) содержится <code>method_data</code> (атрибуты из backend-файла) и <code>environment</code> (переменные окружения) (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+  </ul>
+  <p>Парсер backend-файлов проверяет корректность имён методов (<code>is_correct_name</code>) и action_id (<code>is_correct_action_id</code>), собирает массивы и окружение (<code>save_methods_arrays</code>, <code>save_methods_environment</code>) (<a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a>).</p>
+  <h2>Публикация интерфейсов</h2>
+  <p>Корневой интерфейс <code>org.altlinux.alterator.manager</code> объявлен в <a href="../alterator-manager/alterator_manager_default_interfaces.c">alterator_manager_default_interfaces.c</a>. Он предоставляет методы:</p>
+  <ul>
+    <li><code>GetObjects(interface)</code> — список объектов, реализующих указанный интерфейс.</li>
+    <li><code>GetAllObjects()</code>, <code>GetInterfaces(object)</code>, <code>GetAllInterfaces()</code> — навигация по дереву.</li>
+    <li><code>GetSignals(object, interface, method)</code> — перечень сигнальных имён, объявленных в backend-файле для метода.</li>
+    <li><code>GetEnvValue(name)</code>, <code>SetEnvValue(name, value)</code>, <code>UnsetEnvValue(name)</code> — управление переменными окружения клиента.</li>
+  </ul>
+  <p>Методы получают данные непосредственно из <code>backends_data</code> и возвращают результаты через D-Bus (<a href="../alterator-manager/alterator_manager_default_interfaces.c">alterator_manager_default_interfaces.c</a>).</p>
+  <h2>Polkit и безопасность</h2>
+  <p>Менеджер проверяет права вызова на уровне интерфейса и метода. По умолчанию action_id формируется из имени интерфейса, но может быть переопределён в backend-файле. Утилита <code>am-dev-tool</code> генерирует и валидирует policy-файлы (<a href="../alterator-manager/docs/README-ru.md">Раздел «am-dev-tool»</a>).</p>
+  <p>Для удалённых подключений используется модуль <code>remote</code>, который требует парольного агента <code>org.altlinux.PasswordAgent</code> (описание в разделе «password agent» <a href="../alterator-manager/docs/README-ru.md">README</a>).</p>
+  <h2>Переменные окружения отправителя</h2>
+  <p>Менеджер ведёт таблицу <code>sender_environment_data</code>, где для каждого отправителя (уникальное имя D-Bus) хранится набор переменных. Значения из этой таблицы подставляются в переменные окружения методов executor. Очистка неактуальных записей выполняется раз в 10 минут таймером (<a href="../alterator-manager/docs/README-ru.md">Раздел «Переменные окружения»</a> и <a href="../alterator-manager/main.c">main.c</a>).</p>
+  <h2>Мониторинг backend-файлов</h2>
+  <p>Функция <code>alterator_manager_backend_monitor_backends_changed()</code> проверяет директории backends. При обнаружении изменения менеджер завершает работу, а systemd перезапускает службу (<a href="../alterator-manager/main.c">main.c</a> и <a href="../alterator-manager/alterator_manager_backend_monitor.c">alterator_manager_backend_monitor.c</a>).</p>
+  <h2>Поток обработки вызова</h2>
+  <ol>
+    <li>Клиент вызывает метод интерфейса (например, <code>org.altlinux.alterator.service1.Deploy</code>).</li>
+    <li>Менеджер ищет соответствующий <code>InterfaceObjectInfo</code> и <code>MethodObjectInfo</code> в <code>backends_data</code>.</li>
+    <li>Проверяется лимит потоков и action_id для polkit (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+    <li>Менеджер вызывает функцию модуля executor, передавая атрибуты метода (<code>execute</code>, <code>stdin_string</code>, <code>stdout_bytes</code> и др.).</li>
+    <li>Результат и сигналы отправляются клиенту через D-Bus. Клиент может дополнительно подписаться на сигналы stdout/stderr.</li>
+  </ol>
+  <p>Понимание этого конвейера помогает отлаживать backend-файлы и писать модули. Следующая глава описывает сами модули и их формат конфигурации.</p>
+</body>
+</html>

--- a/study/chapter04-modules-and-backends.html
+++ b/study/chapter04-modules-and-backends.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 4. Модули и backend-файлы</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter03-manager-runtime.html">Предыдущая глава</a></nav>
+  <h1>Глава 4. Модули и backend-файлы</h1>
+  <p>Backend-файлы описывают интерфейсы D-Bus, а модули реализуют их поведение. Менеджер загружает backend-файлы из каталогов <code>/usr/share/alterator/backends</code> и <code>/etc/alterator/backends</code>, разбирает TOML и связывает методы с функциями модуля (<a href="../alterator-manager/docs/README-ru.md">docs/README-ru.md</a>).</p>
+  <h2>Общие поля backend-файла</h2>
+  <ul>
+    <li><code>type = "Backend"</code> — фиксированное значение (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+    <li><code>module</code> — имя модуля (например, <code>executor</code>).</li>
+    <li><code>name</code> — узел дерева D-Bus; формирует часть пути объекта.</li>
+    <li><code>interface</code> — имя интерфейса (короткое или полное <code>org.altlinux.alterator.*</code>).</li>
+    <li><code>thread_limit</code> — допустимое число параллельных вызовов методов (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+    <li><code>action_id</code> — идентификатор polkit (можно не задавать; тогда используется значение по умолчанию).</li>
+  </ul>
+  <p>Пример шаблона приведён в <a href="../alterator-test-services/test-service.backend.template">test-service.backend.template</a>.</p>
+  <h2>Описание методов</h2>
+  <p>Каждый метод описывается таблицей <code>[methods.&lt;Имя&gt;]</code>. Допустимые параметры определены модулем:</p>
+  <ul>
+    <li><code>execute</code> — обязательная команда или скрипт.</li>
+    <li><code>stdin_string</code> — флаг передачи строки на stdin.</li>
+    <li><code>stdout_strings</code>, <code>stdout_bytes</code>, <code>stdout_byte_arrays</code>, <code>stdout_string_array</code>, <code>stdout_json</code> — режимы чтения вывода (<a href="../alterator-manager/docs/README-ru.md">Раздел «executor»</a>).</li>
+    <li><code>stderr_strings</code> — возврат stderr в виде массива строк.</li>
+    <li><code>stdout_signal_name</code>, <code>stderr_signal_name</code> — имена сигналов, транслирующих вывод (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+    <li><code>timeout</code> — ограничение времени выполнения в секундах.</li>
+    <li><code>environment</code> — подтаблицы переменных окружения с полями <code>default</code> и <code>required</code>.</li>
+  </ul>
+  <p>Для методов executor действуют ограничения: разрешён один тип stdout-режима, приоритет — <code>stdout_strings</code> → <code>stdout_bytes</code> → <code>stdout_byte_arrays</code> → <code>stdout_string_array</code> → <code>stdout_json</code> (<a href="../alterator-manager/docs/README-ru.md">README</a>).</p>
+  <h2>Модуль executor</h2>
+  <p>Executor запускает внешние команды. Backend-файл для сервиса включает методы <code>Info</code>, <code>Deploy</code>, <code>Start</code>, <code>Stop</code>, <code>Configure</code>, <code>Status</code> и др. (<a href="../alterator-test-services/test-service.backend.template">шаблон</a>). В методах <code>Deploy</code> и <code>Undeploy</code> обычно включена передача stdin и сигналы для вывода.</p>
+  <p>В исходнике <a href="../alterator-manager/docs/README-ru.md">README</a> описаны дополнительные параметры:</p>
+  <ul>
+    <li><code>stdout_byte_limit</code>, <code>stdout_strings_limit</code>, <code>stderr_strings_limit</code> — ограничения на размер выводимых массивов.</li>
+    <li><code>stdout_json</code> — список ключей, извлекаемых из JSON-объекта stdout (возвращает несколько значений).</li>
+    <li><code>environment.&lt;VAR&gt;.default</code> — значение по умолчанию, которое может быть переопределено через методы менеджера (<a href="../alterator-manager/docs/README-ru.md">Раздел «executor»</a>).</li>
+  </ul>
+  <h2>Модуль remote</h2>
+  <p>Remote организует подключение к удалённому менеджеру через SSH. Описание методов (Connect, Disconnect и др.) находится в <a href="../alterator-manager/docs/README-ru.md">разделе «remote»</a>. Модуль не использует backend-файлы: он экспортирует интерфейс <code>org.altlinux.alterator.Remote</code> напрямую и взаимодействует с password agent.</p>
+  <h2>Backend для диагностических интерфейсов</h2>
+  <p>Диагностические инструменты оформляются отдельным backend-файлом (см. <a href="../alterator-test-services/test-service-diag.backend.template">test-service-diag.backend.template</a>). Интерфейс <code>diag1</code> предоставляет методы:</p>
+  <ul>
+    <li><code>Info</code> — отдаёт Entry-файл диагностики (<code>stdout_bytes</code>).</li>
+    <li><code>Run</code> — запускает helper с параметрами и транслирует stdout/stderr через сигналы.</li>
+    <li><code>List</code>, <code>Report</code> — возвращают список тестов или отчёт (строковый/байтовый вывод).</li>
+  </ul>
+  <p>Переменные окружения для списка тестов задаются через секцию <code>[methods.List.environment.*]</code> (<a href="../alterator-test-services/test-service-diag.backend.template">шаблон</a>).</p>
+  <h2>Проверка соответствия интерфейсу</h2>
+  <p>Менеджер сверяет backend с XML-описанием интерфейса в <code>/usr/share/dbus-1/interfaces</code>. Валидация не пройдёт, если отсутствуют методы, описанные в шаблоне, или сигнатуры не совпадают (<a href="../alterator-manager/docs/README-ru.md">Раздел «Валидация интерфейсов»</a>).</p>
+  <h2>Пример: backend пакетов</h2>
+  <p>Каталог <a href="../alterator-backend-packages/apt">alterator-backend-packages/apt</a> содержит backend <a href="../alterator-backend-packages/apt/apt.backend">apt.backend</a>, который использует executor для управления пакетами через <code>apt-get</code> и wrapper-скрипты. Методы включают <code>UpdateAsync</code>, <code>ApplyAsync</code>, <code>Search</code>, <code>DistUpgradeAsync</code>, возвращающие массивы строк и пересылающие stdout/stderr сигналами.</p>
+  <h2>Практические шаги по созданию backend</h2>
+  <ol>
+    <li>Сформировать Entry-файл сервиса или диагностики (см. главу 2).</li>
+    <li>Создать backend-файл с описанием интерфейса и методов. Проверить корректность имён и опций.</li>
+    <li>Разместить файл в <code>/usr/share/alterator/backends</code> или <code>/etc/alterator/backends</code> в зависимости от режима.</li>
+    <li>Перезапустить <code>alterator-manager</code> или дождаться автоматического перезапуска после изменения файлов.</li>
+    <li>Проверить доступность методов через D-Bus (например, <code>gdbus call</code>) и убедиться, что сигналы зарегистрированы методом <code>GetSignals</code>.</li>
+  </ol>
+  <p>Следующая глава описывает полный жизненный цикл сервиса, включая helper-скрипты и интерфейс service1.</p>
+</body>
+</html>

--- a/study/chapter05-service-lifecycle.html
+++ b/study/chapter05-service-lifecycle.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 5. Жизненный цикл сервиса</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter04-modules-and-backends.html">Предыдущая глава</a></nav>
+  <h1>Глава 5. Жизненный цикл сервиса</h1>
+  <p>Сервис Alterator описывается тремя слоями: Entry-файл типа <code>service</code>, backend-интерфейс <code>service1</code> и helper-утилита. Эта глава показывает, как данные проходят от описания до выполнения команд.</p>
+  <h2>Сущность service</h2>
+  <p>Структура <code>.service</code> определяется спецификацией (<a href="../interface-service.wiki">interface-service.wiki</a> и <a href="../alterator-interface-service/doc/README.md">alterator-interface-service/doc/README.md</a>). В файле задаются:</p>
+  <ul>
+    <li><code>type = "Service"</code>, <code>name</code>, <code>category</code>, <code>display_name.*</code>, <code>comment.*</code>.</li>
+    <li>Флаги <code>enable_force_deploy</code>, <code>no_default_diag</code> (если диагностика не нужна).</li>
+    <li>Секции <code>[parameters.*]</code>, <code>[types.*]</code>, <code>[resources.*]</code>, <code>[services.*]</code> (<a href="../alterator-manager-servises.wiki">alterator-manager-servises.wiki</a>).</li>
+    <li>Привязки к diag-инструментам через <code>[diag_tools]</code> (<a href="../alterator-test-services/test_service1/test_service1.service">пример test_service1</a>).</li>
+  </ul>
+  <p>Контексты параметров определяют, в какие методы backend они передаются: <code>deploy</code>, <code>configure</code>, <code>status</code>, <code>backup</code>, <code>restore</code>, <code>undeploy</code>, <code>diag</code> (<a href="../interface-service.wiki">interface-service.wiki</a>).</p>
+  <h2>Backend интерфейса service1</h2>
+  <p>Backend-файл связывает Entry и helper (см. <a href="../alterator-service-chrony/service-chrony.backend">service-chrony.backend</a> и <a href="../alterator-test-services/test-service.backend.template">шаблон</a>). Методы:</p>
+  <ul>
+    <li><code>Info</code> — возвращает содержимое <code>.service</code> файла (<code>stdout_bytes = true</code>).</li>
+    <li><code>Deploy</code>, <code>Undeploy</code>, <code>Configure</code> — вызывают helper с режимами <code>-d</code>, <code>-u</code>, <code>-c</code>, передавая параметры в stdin.</li>
+    <li><code>Start</code>, <code>Stop</code> — запускают или останавливают systemd-юниты.</li>
+    <li><code>Backup</code>, <code>Restore</code> — управляют резервным копированием.</li>
+    <li><code>Status</code> — выдаёт текущее состояние (байтовый поток или строки).</li>
+  </ul>
+  <p>Сигналы <code>service_stdout_signal</code> и <code>service_stderr_signal</code> транслируют ход операций (<a href="../alterator-interface-service/doc/README.md">README</a>).</p>
+  <h2>Helper-утилита</h2>
+  <p>Helper реализует реальную логику сервиса. В тестовом наборе <a href="../alterator-test-services/test-services-helper">test-services-helper</a> используются опции:</p>
+  <ul>
+    <li><code>--deploy</code>, <code>--undeploy</code>, <code>--configure</code>, <code>--start</code>, <code>--stop</code>, <code>--status</code>, <code>--backup</code>, <code>--restore</code>.</li>
+    <li><code>--service</code> для выбора Entry-файла и каталога кэша.</li>
+    <li><code>--input</code> или stdin для получения JSON с параметрами.</li>
+  </ul>
+  <p>В режиме <code>deploy</code> helper валидирует параметры через JSON Schema, сохраняет конфигурацию в <code>/etc/test-services/&lt;service&gt;.conf</code>, создаёт отметку развёртывания и формирует вывод (<a href="../alterator-test-services/test-services-helper">test-services-helper</a>).</p>
+  <p><code>status</code> читает конфигурацию, фильтрует значения по контексту с помощью <code>taplo</code>, и возвращает JSON; коды возврата 127/128 сигнализируют о развёрнутом состоянии (<a href="../alterator-test-services/test-services-helper">скрипт</a>).</p>
+  <p>Боевые сервисы, такие как Chrony, используют отдельный helper (<a href="../alterator-service-chrony/service-chrony/service-chrony">service-chrony</a>), который управляет конфигурацией и systemd-юнитами chronyd.</p>
+  <h2>Диагностика</h2>
+  <p>Диагностические описания (<code>.diag</code>) содержат наборы тестов. Пример — <a href="../alterator-test-services/test_service1/test_service1.diag">test_service1.diag</a>. Backend <code>diag1</code> запускает <a href="../alterator-test-services/diag-helper">diag-helper</a>, который умеет перечислять тесты (<code>-l</code>), выполнять и формировать отчёты (<code>-r</code>) (<a href="../alterator-test-services/test-service-diag.backend.template">шаблон</a>).</p>
+  <h2>Интерфейс пользователя</h2>
+  <p>GUI модуль <a href="../alterator-manager-servises.wiki">alterator-manager-services</a> отображает:</p>
+  <ul>
+    <li>Список сервисов в левой панели, статус и параметры — в правой.</li>
+    <li>Кнопки «Развернуть/Отменить», «Запустить/Остановить», «Настроить».</li>
+    <li>Вкладки «Параметры» и «Ресурсы», заполняемые на основе <code>.service</code> файла.</li>
+  </ul>
+  <p>При развертывании показывается диалог конфигурации и окно логов. Ресурсы (файлы, каталоги, юниты, порты) берутся из секции <code>[resources]</code> и используются для выявления конфликтов (<a href="../alterator-manager-servises.wiki">wiki</a>).</p>
+  <h2>Типовой сценарий</h2>
+  <ol>
+    <li>Администратор выбирает сервис в GUI/CLI. Клиент вызывает <code>Info</code>, получает Entry, выводит параметры.</li>
+    <li>Пользователь вводит значения. Клиент формирует JSON и вызывает метод <code>Deploy</code> интерфейса service1.</li>
+    <li>Менеджер передаёт JSON helper-утилите. Helper проверяет схему, применяет настройки, обновляет ресурсы.</li>
+    <li>Helper выводит ход операции в stdout/stderr. Менеджер пересылает данные клиенту через сигналы.</li>
+    <li>После завершения helper возвращает код: <code>0</code> — успех, <code>&gt;0</code> — ошибка. Клиент отображает лог и статус.</li>
+    <li>Дальнейшее управление (configure/start/stop/backup/restore) повторяет те же шаги, используя свои контексты.</li>
+  </ol>
+  <p>Такой конвейер одинаков для тестовых и боевых сервисов. Различаются только параметры и реализующий helper.</p>
+</body>
+</html>

--- a/study/chapter06-interface-and-tools.html
+++ b/study/chapter06-interface-and-tools.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 6. Пользовательские интерфейсы и утилиты</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter05-service-lifecycle.html">Предыдущая глава</a></nav>
+  <h1>Глава 6. Пользовательские интерфейсы и утилиты</h1>
+  <p>Alterator предоставляет графический и консольный доступ к сервисам, а также служебные инструменты для работы с Entry-файлами и пакетами.</p>
+  <h2>Alterator Manager Services (GUI)</h2>
+  <p>Вики <a href="../alterator-manager-servises.wiki">alterator-manager-servises.wiki</a> описывает интерфейс:</p>
+  <ul>
+    <li>Левая панель — список сервисов. Правая — сведения о выбранном сервисе, статус и кнопки управления.</li>
+    <li>Вкладка «Параметры» отображает поля <code>[parameters]</code> сущности service, «Ресурсы» — секцию <code>[resources]</code>.</li>
+    <li>Кнопки «Развернуть/Отменить», «Запустить/Остановить», «Настроить» вызывают методы service1 (Deploy/Undeploy/Start/Stop/Configure).</li>
+    <li>При развертывании запускается диалог конфигурации и окно логов, выводимое через сигналы backend.</li>
+  </ul>
+  <p>GUI ориентирован на администраторов: проверяет конфликты ресурсов, показывает лог операций и поддерживает установку тестовых сервисов.</p>
+  <h2>Alteratorctl (CLI)</h2>
+  <p>Консольная утилита <a href="../alteratorctl">alteratorctl</a> регистрирует модули (manager, packages, components, editions, diag, systeminfo) и подключается к D-Bus менеджера (<a href="../alteratorctl/main.c">main.c</a>). Каждая команда реализована отдельным модулем:</p>
+  <ul>
+    <li><code>alteratorctl manager ...</code> — управление backend-объектами через интерфейс manager.</li>
+    <li><code>alteratorctl packages ...</code> — взаимодействие с backend пакетов (apt) (<a href="../alterator-backend-packages/apt/apt.backend">apt.backend</a>).</li>
+    <li><code>alteratorctl components ...</code>, <code>alteratorctl editions ...</code> — работа с Entry-файлами компонентов и изданий.</li>
+    <li><code>alteratorctl diag ...</code> — запуск диагностик (<code>diag1</code>).</li>
+  </ul>
+  <p>Утилита использует gettext и поддерживает локализацию (<a href="../alteratorctl/main.c">main.c</a>). Модули получают доступ к D-Bus через общие функции из <a href="../alteratorctl/alteratorctlgdbussource.c">alteratorctlgdbussource.c</a> (при необходимости изучить код).</p>
+  <h2>Alterator Entry CLI</h2>
+  <p>Скрипт <a href="../alterator-entry/scripts/alterator-entry">alterator-entry</a> предоставляет команды:</p>
+  <ul>
+    <li><code>alterator-entry get файл путь</code> — получить значение поля, включая списки (использует функцию <code>get_field()</code> из <a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>).</li>
+    <li><code>alterator-entry validate файл...</code> — проверить соответствие JSON Schema (<a href="../alterator-entry/alterator_entry/alterator_entry.py">validate()</a>).</li>
+  </ul>
+  <p>Скрипт возвращает коды 0/1 в зависимости от результата, что удобно для интеграции в CI/CD.</p>
+  <h2>editions2packages</h2>
+  <p>Утилита <a href="../alterator-entry/scripts/editions2packages">editions2packages</a> вытягивает пакеты из изданий и компонентов. Она читает <code>.edition</code> файлы, фильтрует секции, архитектуры, десктопы и языки, используя <code>PackagesFilterOptions</code> из <a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a>. Результат выводится как список имён пакетов, пригодный для генерации образов.</p>
+  <h2>Политики и безопасность</h2>
+  <p>Инструмент <code>am-dev-tool</code> из пакета alterator-manager-tools генерирует polkit-политики и валидирует существующие (<a href="../alterator-manager/docs/README-ru.md">раздел «am-dev-tool»</a>). Команды:</p>
+  <pre><code>am-dev-tool -g /usr/share/alterator/backends/&lt;имя&gt;.backend -o policy.file
+am-dev-tool -t /usr/share/alterator/backends/&lt;имя&gt;.backend</code></pre>
+  <p>Генерация полезна при добавлении новых backend-файлов, чтобы сразу настроить правила доступа.</p>
+  <h2>Интерфейс service1</h2>
+  <p>Документация <a href="../alterator-interface-service/doc/README.md">alterator-interface-service/doc/README.md</a> описывает сигнатуры методов и сигналов интерфейса <code>org.altlinux.alterator.service1</code>. Они служат контрактом между клиентами и backend. Сигналы <code>service_stdout_signal</code>/<code>service_stderr_signal</code> выдаются helper-утилитами, что позволяет отображать прогресс в GUI/CLI.</p>
+  <h2>Рекомендации по использованию инструментов</h2>
+  <ul>
+    <li>Перед загрузкой сервиса в GUI проверьте <code>.service</code> и <code>.backend</code> через <code>alterator-entry validate</code> и <code>am-dev-tool -t</code>.</li>
+    <li>Используйте <code>alteratorctl</code> для автоматизированных сценариев (развёртывание в CI, smoke-тесты).</li>
+    <li>Для подготовки образов формируйте список пакетов через <code>editions2packages</code> с нужными фильтрами (архитектура, язык).</li>
+  </ul>
+  <p>Освоив интерфейсы и утилиты, можно переходить к процессу разработки и тестирования новых компонентов.</p>
+</body>
+</html>

--- a/study/chapter07-development-workflow.html
+++ b/study/chapter07-development-workflow.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 7. Практика разработки и тестирования</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter06-interface-and-tools.html">Предыдущая глава</a></nav>
+  <h1>Глава 7. Практика разработки и тестирования</h1>
+  <p>Для добавления нового сервиса или компонента в Alterator требуется последовательный процесс: проектирование Entry-файла, создание backend-интерфейса, написание helper-скрипта, настройка политик и тестирование. Этот раздел описывает рекомендуемые шаги и инструменты проверки.</p>
+  <h2>Подготовка описания</h2>
+  <ol>
+    <li>Изучить спецификацию Alterator Entry (<a href="../alterator-entry/doc/README.md">README</a>) и существующие примеры (<a href="../alterator-test-services/test_service1/test_service1.service">test_service1.service</a>, <a href="../alterator-service-chrony/service-chrony.service">service-chrony.service</a>).</li>
+    <li>Определить параметры, контексты и ресурсы. Для составных объектов подготовить секции <code>[types]</code> с шаблонами.</li>
+    <li>Создать JSON Schema для валидации входных данных helper (см. <a href="../alterator-test-services/schema-generator">schema-generator</a> как пример).</li>
+  </ol>
+  <h2>Разработка backend-файла</h2>
+  <ol>
+    <li>Базироваться на шаблоне <a href="../alterator-test-services/test-service.backend.template">test-service.backend.template</a> и адаптировать команды <code>execute</code>.</li>
+    <li>Указать сигналы stdout/stderr для методов с длительными операциями.</li>
+    <li>Задать <code>timeout</code>, <code>thread_limit</code>, <code>environment</code> при необходимости.</li>
+    <li>Проверить backend командой <code>am-dev-tool -t</code> и убедиться, что имена методов соответствуют XML-интерфейсу (<a href="../alterator-manager/docs/README-ru.md">раздел «Валидация интерфейсов»</a>).</li>
+  </ol>
+  <h2>Helper и скрипты обслуживания</h2>
+  <p>Helper должен обрабатывать все режимы, используемые backend:</p>
+  <ul>
+    <li>Вход — JSON со значениями параметров (см. обработку stdin в <a href="../alterator-test-services/test-services-helper">test-services-helper</a>).</li>
+    <li>Валидация — через <code>jsonschema</code> или собственные проверки (см. функции <code>validate_json</code>, <code>parse_json</code> в helper тестовых сервисов).</li>
+    <li>Логи — печать человекочитаемых шагов и ошибок в stdout/stderr для отображения в GUI/CLI.</li>
+    <li>Коды возврата — 0 для успеха, отдельные значения для частных случаев (например, 127/128 для статуса в тестовом helper).</li>
+  </ul>
+  <p>Для сложных сервисов helper может вызывать системные утилиты (systemctl, tar, конфигураторы). Пример комплексного скрипта — <a href="../alterator-service-chrony/service-chrony/service-chrony">service-chrony</a>.</p>
+  <h2>Политики и безопасность</h2>
+  <ul>
+    <li>Сгенерировать polkit-политику утилитой <code>am-dev-tool -g</code> и адаптировать описание прав (<a href="../alterator-manager/docs/README-ru.md">README</a>).</li>
+    <li>Проверить, что action_id методов согласованы с политикой (<code>action_id</code> в backend).</li>
+    <li>Настроить SELinux/аппармор при необходимости (зависит от окружения; в рамках курса см. системную документацию).</li>
+  </ul>
+  <h2>Тестовые сервисы</h2>
+  <p>Репозиторий <a href="../alterator-test-services">alterator-test-services</a> предоставляет образцы и инфраструктуру:</p>
+  <ul>
+    <li>Директории <code>test_service1..4</code> демонстрируют разные типы параметров, массивов, групп и диагностик.</li>
+    <li>Скрипт <code>test-services-helper</code> показывает шаблон обработки режимов и проверки схем.</li>
+    <li>Шаблоны backend и diag помогают быстро создать новые сервисы.</li>
+  </ul>
+  <p>Рекомендуется развернуть тестовые сервисы на стенде (<code>apt-get install alterator-test-services</code>, см. <a href="../alterator-manager-servises.wiki">wiki</a>) и проверить взаимодействие GUI/CLI.</p>
+  <h2>Отладка и диагностика</h2>
+  <ul>
+    <li>Включить debug-режим менеджера (<code>alterator-manager --debug</code>) для подробных логов (<a href="../alterator-manager/main.c">main.c</a>).</li>
+    <li>Использовать <code>gdbus introspect</code> и <code>gdbus call</code> для проверки доступности методов.</li>
+    <li>Отслеживать события в <code>journalctl -u alterator-manager</code> (systemd запускает службу по unit-файлу <a href="../alterator-manager/alterator-manager.service">alterator-manager.service</a>).</li>
+    <li>Проверять переменные окружения методом <code>GetEnvValue</code> интерфейса manager (<a href="../alterator-manager/alterator_manager_default_interfaces.c">alterator_manager_default_interfaces.c</a>).</li>
+  </ul>
+  <h2>Автоматизация проверок</h2>
+  <ul>
+    <li>Добавить <code>alterator-entry validate</code> и <code>am-dev-tool -t</code> в CI, чтобы отклонять некорректные описания.</li>
+    <li>Для helper-скриптов подготовить unit-тесты или сценарии с фиктивными конфигурациями (см. директорию <a href="../alterator-test-services/test_service1/tests">tests</a> для примеров).</li>
+    <li>Использовать <code>alteratorctl</code> в автоматизированных тестах для имитации действий пользователя.</li>
+  </ul>
+  <p>После прохождения тестов и ревью Entry-файлы, backend и helper устанавливаются в соответствующие каталоги, и сервис готов к эксплуатации.</p>
+</body>
+</html>

--- a/study/chapter08-directory-reference.html
+++ b/study/chapter08-directory-reference.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Глава 8. Каталоги репозитория</title>
+</head>
+<body>
+  <nav><a href="index.html">На главную</a> · <a href="chapter07-development-workflow.html">Предыдущая глава</a></nav>
+  <h1>Глава 8. Каталоги репозитория</h1>
+  <p>Раздел содержит карту репозитория и назначение ключевых каталогов. Используйте её для навигации и поиска примеров.</p>
+  <h2>Корневой уровень</h2>
+  <ul>
+    <li><strong>alterator-entry/</strong> — библиотека и утилиты для работы с Entry-файлами. Важные файлы: <a href="../alterator-entry/doc/README.md">doc/README.md</a> (спецификация), <a href="../alterator-entry/alterator_entry/alterator_entry.py">alterator_entry.py</a> (API), <a href="../alterator-entry/scripts/alterator-entry">scripts/alterator-entry</a> (CLI), <a href="../alterator-entry/scripts/editions2packages">scripts/editions2packages</a> (извлечение пакетов), <a href="../alterator-entry/schemas">schemas/</a> (JSON Schema).</li>
+    <li><strong>alterator-manager/</strong> — исходники демона Alterator Manager: <a href="../alterator-manager/main.c">main.c</a>, <a href="../alterator-manager/alterator_manager_backends.c">alterator_manager_backends.c</a>, <a href="../alterator-manager/alterator_manager_default_interfaces.c">alterator_manager_default_interfaces.c</a>, <a href="../alterator-manager/alterator_manager_modules.c">alterator_manager_modules.c</a>, документация <a href="../alterator-manager/docs/README-ru.md">docs/README-ru.md</a>, unit-файлы и политики.</li>
+    <li><strong>alterator-interface-service/</strong> — описание интерфейса <code>service1</code>: <a href="../alterator-interface-service/doc/README.md">doc/README.md</a>, <a href="../alterator-interface-service/org.altlinux.alterator.service1.xml">XML</a>, <a href="../alterator-interface-service/org.altlinux.alterator.service1.policy">policy</a>.</li>
+    <li><strong>alterator-backend-packages/</strong> — backend для управления пакетами. Каталог <a href="../alterator-backend-packages/apt">apt/</a> содержит <a href="../alterator-backend-packages/apt/apt.backend">apt.backend</a>, wrapper-скрипты и политику.</li>
+    <li><strong>alterator-test-services/</strong> — набор учебных сервисов. Содержит директории <a href="../alterator-test-services/test_service1">test_service1</a>…<a href="../alterator-test-services/test_service4">test_service4</a>, helper <a href="../alterator-test-services/test-services-helper">test-services-helper</a>, шаблоны <a href="../alterator-test-services/test-service.backend.template">test-service.backend.template</a> и <a href="../alterator-test-services/test-service-diag.backend.template">test-service-diag.backend.template</a>, генератор схем <a href="../alterator-test-services/schema-generator">schema-generator</a>.</li>
+    <li><strong>alterator-service-chrony/</strong> — пример промышленного сервиса: <a href="../alterator-service-chrony/service-chrony.service">service-chrony.service</a>, <a href="../alterator-service-chrony/service-chrony.backend">service-chrony.backend</a>, helper <a href="../alterator-service-chrony/service-chrony/service-chrony">service-chrony</a>.</li>
+    <li><strong>alterator-service-samba-share/</strong>, <strong>alterator-service-vsftpd/</strong>, <strong>alterator-service-chrony</strong> и другие каталоги <code>alterator-service-*</code> — готовые сервисы по аналогии с Chrony (изучите пары <code>.service</code>/<code>.backend</code> и helper-скрипты).</li>
+    <li><strong>alterator-manager-servises.wiki</strong> — описание GUI и пользовательского сценария (<a href="../alterator-manager-servises.wiki">файл</a>).</li>
+    <li><strong>interface-service.wiki</strong> — расширенные заметки по сущности service и интерфейсу <code>service1</code>.</li>
+    <li><strong>alteratorctl/</strong> — исходники консольной утилиты: <a href="../alteratorctl/main.c">main.c</a>, модули <a href="../alteratorctl/alteratorctlmanagermodule.c">alteratorctlmanagermodule.c</a>, <a href="../alteratorctl/alteratorctlpackagesmodule.c">alteratorctlpackagesmodule.c</a>, <a href="../alteratorctl/alteratorctlgdbussource.c">alteratorctlgdbussource.c</a>.</li>
+    <li><strong>alterator-entry/doc/</strong> — дополнительные документы по спецификации (см. <a href="../alterator-entry/doc/alterator-diag.txt">alterator-diag.txt</a>, <a href="../alterator-entry/doc/desktop-entry.txt">desktop-entry.txt</a>).</li>
+    <li><strong>alterator-manager/docs/</strong> — документация по backend, модулям, polkit и remote (<a href="../alterator-manager/docs/README-ru.md">README-ru.md</a>).</li>
+  </ul>
+  <h2>Дополнительные файлы</h2>
+  <ul>
+    <li><strong>examples.txt</strong> — образцы оформления документации.</li>
+    <li><strong>AGENTS.md</strong> — инструкции по стилю и приоритетам обновления документации.</li>
+    <li><strong>apt1.md</strong> — справочные заметки по backend пакетов.</li>
+  </ul>
+  <h2>Где размещать новые файлы</h2>
+  <ul>
+    <li>Entry-файлы сервисов — <code>/usr/share/alterator/services</code> или <code>/etc/alterator/services</code> (см. <a href="../alterator-entry/doc/README.md">спецификацию</a>).</li>
+    <li>Backend-файлы — <code>/usr/share/alterator/backends</code> или <code>/etc/alterator/backends</code>, подкаталоги <code>system</code>/<code>user</code> (<a href="../alterator-entry/doc/README.md">README</a>).</li>
+    <li>Helper-скрипты — <code>/usr/lib/&lt;пакет&gt;/</code> или <code>/usr/bin/</code> (пример: <a href="../alterator-service-chrony/service-chrony/service-chrony">service-chrony</a>).</li>
+    <li>Диагностические описания — <code>/usr/share/alterator/&lt;имя&gt;_diag</code> (пример: <a href="../alterator-test-services/test_service1/test_service1.diag">test_service1.diag</a>).</li>
+    <li>JSON Schema для helper — рядом с helper (см. <a href="../alterator-test-services/test-services-helper">test-services-helper</a>).</li>
+  </ul>
+  <h2>Полезные ориентиры</h2>
+  <ul>
+    <li>Примеры сложных параметров и ресурсов — <a href="../alterator-test-services/test_service1/test_service1.service">test_service1.service</a>.</li>
+    <li>Пример насыщенного backend — <a href="../alterator-backend-packages/apt/apt.backend">apt.backend</a>.</li>
+    <li>Механизм загрузки модулей — <a href="../alterator-manager/alterator_manager_modules.c">alterator_manager_modules.c</a>.</li>
+  </ul>
+  <p>Карта каталогов завершает курс: теперь можно уверенно ориентироваться в репозитории и переходить к практической разработке.</p>
+</body>
+</html>

--- a/study/index.html
+++ b/study/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>Alterator: учебный курс</title>
+  <style>
+    body { font-family: sans-serif; line-height: 1.5; margin: 2rem; }
+    nav ul { list-style: none; padding: 0; }
+    nav li { margin: 0.3rem 0; }
+    a { color: #004080; }
+  </style>
+</head>
+<body>
+  <h1>Alterator: учебный курс</h1>
+  <p>Курс описывает архитектуру Alterator и порядок работы с кодовой базой. Материал предназначен для начинающих разработчиков, которые хотят понимать устройство менеджера, сервисов и инструментов проекта на уровне архитектора.</p>
+  <p>Структура курса построена по главам. Каждая глава посвящена отдельной подсистеме и содержит ссылки на исходные файлы репозитория.</p>
+  <nav>
+    <h2>Содержание</h2>
+    <ul>
+      <li><a href="chapter01-overview.html">Глава 1. Общая архитектура</a></li>
+      <li><a href="chapter02-entry-model.html">Глава 2. Формат Alterator Entry и схемы</a></li>
+      <li><a href="chapter03-manager-runtime.html">Глава 3. Alterator Manager и цикл выполнения</a></li>
+      <li><a href="chapter04-modules-and-backends.html">Глава 4. Модули и backend-файлы</a></li>
+      <li><a href="chapter05-service-lifecycle.html">Глава 5. Жизненный цикл сервиса</a></li>
+      <li><a href="chapter06-interface-and-tools.html">Глава 6. Пользовательские интерфейсы и утилиты</a></li>
+      <li><a href="chapter07-development-workflow.html">Глава 7. Практика разработки и тестирования</a></li>
+      <li><a href="chapter08-directory-reference.html">Глава 8. Каталоги репозитория</a></li>
+    </ul>
+  </nav>
+  <p>Рекомендуется изучать главы последовательно: каждая следующая глава опирается на понятия из предыдущих.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Добавлена структура учебного курса в каталоге `study/` с оглавлением и восемью главами
- Описаны архитектура Alterator, формат Alterator Entry, менеджер, модули, сервисы, интерфейсы и инструменты с прямыми ссылками на исходные файлы
- Подготовлена итоговая карта каталогов проекта для быстрой навигации

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1af08f708832ca2ba3397a06be8a2